### PR TITLE
[Feature]: Simply apply wallpaper to all monitors

### DIFF
--- a/scripts/set_wallpaper.sh
+++ b/scripts/set_wallpaper.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-echo "preload = $1" > ~/.config/hypr/hyprpaper.conf
-for monitor in $(hyprctl monitors | grep 'Monitor' | awk '{ print $2 }'); do
-    echo -e "wallpaper = $monitor,$1" >> ~/.config/hypr/hyprpaper.conf
-done
-echo -e "ipc = off\nsplash = off" >> ~/.config/hypr/hyprpaper.conf
+echo "preload = $1" >~/.config/hypr/hyprpaper.conf
+echo -e "wallpaper = , $1" >>~/.config/hypr/hyprpaper.conf
+echo -e "ipc = off\nsplash = off" >>~/.config/hypr/hyprpaper.conf

--- a/scripts/wallpaper.py
+++ b/scripts/wallpaper.py
@@ -11,7 +11,7 @@ def set_wallpaper(path):
     os.system('pkill hyprpaper')
     if os.path.isfile(path):
         with open(hyprpaper_conf, 'w') as conf:
-            conf.write(f"preload = {path}\nwallpaper =  eDP-1,{path}\nipc = off\nsplash = off")
+            conf.write(f"preload = {path}\nwallpaper = , {path}\nipc = off\nsplash = off")
         
         os.system('pkill hyprpaper')
 


### PR DESCRIPTION
Instead of fetching monitor names from hyprctl monitors, we can simply apply the wallpaper to all monitors.